### PR TITLE
allow buckets incompatible with s3

### DIFF
--- a/api/src/main/java/io/minio/BucketArgs.java
+++ b/api/src/main/java/io/minio/BucketArgs.java
@@ -47,13 +47,15 @@ public abstract class BucketArgs extends BaseArgs {
                 + "http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html";
         throw new IllegalArgumentException(name + " : " + msg);
       }
-      // Bucket names should be dns compatible.
-      if (!name.matches("^[a-z0-9][a-z0-9\\.\\-]+[a-z0-9]$")) {
-        String msg =
-            "bucket name does not follow Amazon S3 standards. For more information refer "
-                + "http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html";
-        throw new IllegalArgumentException(name + " : " + msg);
-      }
+      /**
+       * Not a requirement for minio itself // Bucket names should be dns compatible.
+       * if (!name.matches("^[a-z0-9][a-z0-9\\.\\-]+[a-z0-9]$")) {
+       *  String msg =
+       *      "bucket name does not follow Amazon S3 standards. For more information refer "
+       *          + "http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html";
+       *  throw new IllegalArgumentException(name + " : " + msg);
+       *}
+       */
     }
 
     private void validateRegion(String region) {

--- a/api/src/main/java/io/minio/MinioClient.java
+++ b/api/src/main/java/io/minio/MinioClient.java
@@ -677,13 +677,14 @@ public class MinioClient {
               + "http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html";
       throw new InvalidBucketNameException(name, msg);
     }
-    // Bucket names should be dns compatible.
-    if (!name.matches("^[a-z0-9][a-z0-9\\.\\-]+[a-z0-9]$")) {
-      String msg =
-          "bucket name does not follow Amazon S3 standards. For more information refer "
-              + "http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html";
-      throw new InvalidBucketNameException(name, msg);
-    }
+
+    /**
+     * Not a requirement for minio itself // Bucket names should be dns compatible. if
+     * (!name.matches("^[a-z0-9][a-z0-9\\.\\-]+[a-z0-9]$")) { String msg = xx "bucket name does not
+     * follow Amazon S3 standards. For more information refer " +
+     * "http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html"; throw new
+     * InvalidBucketNameException(name, msg); }
+     */
   }
 
   private void checkObjectName(String objectName) throws IllegalArgumentException {

--- a/api/src/main/java/io/minio/PutObjectArgs.java
+++ b/api/src/main/java/io/minio/PutObjectArgs.java
@@ -22,7 +22,7 @@ import java.io.InputStream;
 
 /** Argument class of MinioClient.putObject(). */
 public class PutObjectArgs extends PutObjectBaseArgs {
-  private BufferedInputStream stream;
+  protected BufferedInputStream stream;
 
   public BufferedInputStream stream() {
     return stream;

--- a/api/src/main/java/io/minio/PutObjectArgs.java
+++ b/api/src/main/java/io/minio/PutObjectArgs.java
@@ -22,7 +22,7 @@ import java.io.InputStream;
 
 /** Argument class of MinioClient.putObject(). */
 public class PutObjectArgs extends PutObjectBaseArgs {
-  protected BufferedInputStream stream;
+  private BufferedInputStream stream;
 
   public BufferedInputStream stream() {
     return stream;

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ apply plugin: 'io.codearte.nexus-staging'
 
 allprojects {
     group = 'io.minio'
-    version = '7.1.0'
+    version = '7.1.0a-textiq'
     if (!project.hasProperty('release')) {
         version += '-DEV'
     }


### PR DESCRIPTION
S3 has strict rules on bucket names. Since we're using minio for serving files from the file system, buckets don't always adhere to those rules (in particular, `inputData` violates the restriction). Minio doesn't care about bucket names itself (in fact, the minio UI lets you create and read from buckets with incompatible names), but the APIs we are using include a check that reject invalid S3 names. This PR comments out these checks.